### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,6 @@ version: 2
 updates:
   - package-ecosystem: npm
     directory: /
-    schedule: {interval: monthly}
+    schedule: { interval: weekly }
     reviewers: [mahdyar]
     assignees: [mahdyar]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# Docs: <https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/customizing-dependency-updates>
+
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule: {interval: monthly}
+    reviewers: [mahdyar]
+    assignees: [mahdyar]


### PR DESCRIPTION
I already use Dependabot for many projects. With Dependabot it is relatively easy to stay up to date with the dependencies and packages used. Instead of always checking for updates manually, you can e.g. use the dependabot.yml configuration to tell Dependabot to check the project once a week for new releases of the npm dependencies that are used. If there are new updates, a new pull request is automatically created for them.

Since this procedure takes at least some work off my hands over at my projects, I wanted to ask if you would be up to using it as well.